### PR TITLE
Shadow NPC using a type guard

### DIFF
--- a/lib/secure/sefun/combat.test.c
+++ b/lib/secure/sefun/combat.test.c
@@ -44,6 +44,20 @@ void test_combat_tier_from_percent () {
     }) :));
 }
 
+/**
+ * @typedef {STD_NPC & "/std/npc.mock.c"} npcWithMockShadow
+ */
+
+/**
+ * 
+ * @param {"/std/npc.mock.c"} mock 
+ * @param {STD_NPC} ob 
+ * @returns {ob is npcWithMockShadow}
+ */
+int start_mock_shadow(object mock, object ob) {
+    return mock->start_shadow(ob);
+}
+
 void test_combat_messages () {
     object room;
     object npc1, npc2;
@@ -61,8 +75,16 @@ void test_combat_messages () {
     npc2->handle_move(STD_ROOM);
     mockNpc1 = new("/std/npc.mock.c");
     mockNpc2 = new("/std/npc.mock.c");
-    mockNpc1->start_shadow(npc1);
-    mockNpc2->start_shadow(npc2);
+    
+    if (!start_mock_shadow(mockNpc1, npc1)) {
+        throw("Failed to shadow npc1");
+        return;
+    }
+    if (!start_mock_shadow(mockNpc2, npc2)) {
+        throw("Failed to shadow npc2");
+        return;
+    }
+        
     weapon = new(STD_WEAPON);
     weapon->set_name("test weapon");
     weapon->set_type("blade");

--- a/lib/secure/sefun/combat.test.c
+++ b/lib/secure/sefun/combat.test.c
@@ -49,10 +49,10 @@ void test_combat_tier_from_percent () {
  */
 
 /**
- * 
+ * Helper function to start a mock shadow on an npc. 
  * @param {"/std/npc.mock.c"} mock 
  * @param {STD_NPC} ob 
- * @returns {ob is npcWithMockShadow}
+ * @returns {ob is npcWithMockShadow} 1 if successful, 0 if not
  */
 int start_mock_shadow(object mock, object ob) {
     return mock->start_shadow(ob);
@@ -78,7 +78,7 @@ void test_combat_messages () {
     
     if (!start_mock_shadow(mockNpc1, npc1)) {
         throw("Failed to shadow npc1");
-        return;
+        return; // must return so type guard will apply after this point
     }
     if (!start_mock_shadow(mockNpc2, npc2)) {
         throw("Failed to shadow npc2");

--- a/lib/secure/sefun/combat.test.c
+++ b/lib/secure/sefun/combat.test.c
@@ -77,11 +77,11 @@ void test_combat_messages () {
     mockNpc2 = new("/std/npc.mock.c");
     
     if (!start_mock_shadow(mockNpc1, npc1)) {
-        throw("Failed to shadow npc1");
+        error("Failed to shadow npc1");
         return; // must return so type guard will apply after this point
     }
     if (!start_mock_shadow(mockNpc2, npc2)) {
-        throw("Failed to shadow npc2");
+        error("Failed to shadow npc2");
         return;
     }
         

--- a/lib/secure/sefun/combat.test.c
+++ b/lib/secure/sefun/combat.test.c
@@ -78,7 +78,7 @@ void test_combat_messages () {
     
     if (!start_mock_shadow(mockNpc1, npc1)) {
         error("Failed to shadow npc1");
-        return; // must return so type guard will apply after this point
+        return;
     }
     if (!start_mock_shadow(mockNpc2, npc2)) {
         error("Failed to shadow npc2");


### PR DESCRIPTION
@michaelprograms This is testing a way to handle shadowed objects using a helper function with a type guard, and not having to cast each instance of the npc.  Sending a PR in case you find it useful, otherwise, feel free to close/discard.

Note that the returns on line 81 & 85 are required until version 1.1.23 is released, which will properly terminate that branch of the flow node analysis when encountering an `error()` call.